### PR TITLE
use i18n default date format

### DIFF
--- a/app/views/fields/date_picker/_index.html.erb
+++ b/app/views/fields/date_picker/_index.html.erb
@@ -5,7 +5,7 @@ This partial renders a date to be displayed
 on a resource's index page.
 
 By default, the attribute is rendered as string
-with the %b %d, %Y format, e.g. `Oct 28, 2016`
+with the :default format
 
 ## Local variables:
 
@@ -13,4 +13,4 @@ with the %b %d, %Y format, e.g. `Oct 28, 2016`
   An instance of DateTime.
 %>
 
-<%= field.data.strftime('%b %d, %Y') %>
+<%= l field.data %>

--- a/app/views/fields/date_picker/_show.html.erb
+++ b/app/views/fields/date_picker/_show.html.erb
@@ -13,4 +13,4 @@ with the %b %d, %Y format, e.g. `Oct 28, 2016`
   An instance of DateTime.
 %>
 
-<%= field.data.strftime('%b %d, %Y') %>
+<%= l field.data %>

--- a/app/views/fields/date_picker/_show.html.erb
+++ b/app/views/fields/date_picker/_show.html.erb
@@ -5,7 +5,7 @@ This partial renders a date to be displayed
 on a resource's show page.
 
 By default, the attribute is rendered as string
-with the %b %d, %Y format, e.g. `Oct 28, 2016`
+with the :default format
 
 ## Local variables:
 


### PR DESCRIPTION
Hello again @michelegera 👋 What do you think?

Instead of a hardcoded date format re-use `I18n` date format.

📖 http://guides.rubyonrails.org/i18n.html#adding-date-time-formats